### PR TITLE
°C or °F

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,3 +69,5 @@ end
 group :test do
   gem 'webmock'
 end
+
+gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,6 +241,8 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    vcr (6.3.1)
+      base64
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -279,6 +281,7 @@ DEPENDENCIES
   stimulus-rails
   turbo-rails
   tzinfo-data
+  vcr
   web-console
   webmock
 

--- a/app/controllers/weathers_controller.rb
+++ b/app/controllers/weathers_controller.rb
@@ -1,58 +1,26 @@
 class WeathersController < ApplicationController
-  before_action :initialize_services
-
   def index
-    @query = params[:q]
-    fetch_and_handle_weather if @query.present?
-  end
+    @error = nil
+    @forecast = nil
 
-  private
+    if params[:q].present?
+      geocode_service = GeocodeService.new
+      begin
+        location_info = geocode_service.coords_by_zipcode(params[:q])
 
-  def initialize_services
-    @weather_service = WeatherService.new(
-      geocode_service: GeocodeService.new,
-      forecast_service: ForecastService.new
-    )
-  end
-
-  def fetch_and_handle_weather
-    result = @weather_service.fetch_weather(@query)
-    set_weather_data(result)
-  rescue WeatherService::LocationNotFoundError,
-         WeatherService::ForecastUnavailableError,
-         StandardError => e
-    handle_error(e)
-  end
-
-  def set_weather_data(result)
-    @forecast_data = result[:forecast_data]
-    @is_from_cache = result[:is_from_cache]
-    @zip = result[:zip]
-    @country_code = result[:country_code]
-  end
-
-  def handle_error(error)
-    log_error(error)
-    flash.now[:alert] = error_message_for(error)
-    render :index, status: error_status_for(error)
-  end
-
-  def error_message_for(error)
-    case error
-    when WeatherService::LocationNotFoundError
-      "We couldn't find that location. Please check your input and try again."
-    when WeatherService::ForecastUnavailableError
-      "We're sorry, but we can't retrieve the weather information at the moment. Our forecast service might be temporarily unavailable. Please try again later."
-    else
-      "An unexpected error occurred. Our team has been notified."
+        if location_info[:data]
+          forecast_service = ForecastService.new(location_info[:data][:country_code])
+          @forecast = forecast_service.with_lat_lon(location_info[:data][:lat], location_info[:data][:lon])
+        else
+          @error = "Unable to find location information"
+        end
+      rescue GeocodeService::GeocodingError => e
+        @error = "Geocoding error: #{e.message}"
+      rescue ForecastService::ForecastError => e
+        @error = "Forecast error: #{e.message}"
+      rescue StandardError => e
+        @error = "An unexpected error occurred: #{e.message}"
+      end
     end
-  end
-
-  def error_status_for(error)
-    error.is_a?(StandardError) ? :internal_server_error : :unprocessable_entity
-  end
-
-  def log_error(error)
-    Rails.logger.error "Failed to fetch weather: #{error.message}"
   end
 end

--- a/app/controllers/weathers_controller.rb
+++ b/app/controllers/weathers_controller.rb
@@ -6,10 +6,12 @@ class WeathersController < ApplicationController
         location_info = geocode_service.coords_by_zipcode(params[:q])
 
         if location_info[:data]
-          forecast_service = ForecastService.new(location_info[:data][:country_code])
+          country_code = location_info[:data][:country_code]
+          forecast_service = ForecastService.new(country_code)
           @forecast_data = forecast_service.with_lat_lon(location_info[:data][:lat], location_info[:data][:lon])
           @zip = location_info[:data][:zip]
           @is_from_cache = location_info[:is_from_cache]
+          @temp_unit = country_code == 'CA' ? '°C' : '°F'
         else
           flash[:error] = "Unable to find location information"
         end

--- a/app/controllers/weathers_controller.rb
+++ b/app/controllers/weathers_controller.rb
@@ -1,8 +1,5 @@
 class WeathersController < ApplicationController
   def index
-    @error = nil
-    @forecast = nil
-
     if params[:q].present?
       geocode_service = GeocodeService.new
       begin
@@ -10,17 +7,30 @@ class WeathersController < ApplicationController
 
         if location_info[:data]
           forecast_service = ForecastService.new(location_info[:data][:country_code])
-          @forecast = forecast_service.with_lat_lon(location_info[:data][:lat], location_info[:data][:lon])
+          @forecast_data = forecast_service.with_lat_lon(location_info[:data][:lat], location_info[:data][:lon])
+          @zip = location_info[:data][:zip]
+          @is_from_cache = location_info[:is_from_cache]
         else
-          @error = "Unable to find location information"
+          flash[:error] = "Unable to find location information"
         end
       rescue GeocodeService::GeocodingError => e
-        @error = "Geocoding error: #{e.message}"
+        flash[:error] = "Geocoding error: #{e.message}"
       rescue ForecastService::ForecastError => e
-        @error = "Forecast error: #{e.message}"
+        flash[:error] = "Forecast error: #{e.message}"
       rescue StandardError => e
-        @error = "An unexpected error occurred: #{e.message}"
+        flash[:error] = "An unexpected error occurred: #{e.message}"
       end
     end
   end
+
+  private
+
+  def human_readable_time(time)
+    time.strftime("%A, %B %d, %Y %I:%M %p")
+  end
+
+  def is_today?(date)
+    date.to_date == Date.today
+  end
+  helper_method :human_readable_time, :is_today?
 end

--- a/app/models/concerns/retryable.rb
+++ b/app/models/concerns/retryable.rb
@@ -1,0 +1,18 @@
+module Retryable
+  extend ActiveSupport::Concern
+
+  def with_retries(max_retries: 3)
+    retries = 0
+    begin
+      yield
+    rescue StandardError => e
+      retries += 1
+      if retries <= max_retries
+        sleep(2**retries) # Exponential backoff
+        retry
+      else
+        raise e
+      end
+    end
+  end
+end

--- a/app/services/caching_service.rb
+++ b/app/services/caching_service.rb
@@ -3,9 +3,10 @@ class CachingService
   DEFAULT_EXPIRATION = 1.hour.freeze
 
   class << self
-    def fetch(key, expires_in: 1.hour, skip_cache: false)
+    def fetch(key, expires_in: DEFAULT_EXPIRATION, skip_cache: false)
       if !skip_cache && Rails.cache.exist?(key)
-        {data: Rails.cache.read(key), is_from_cache: true}
+        cached_value = Rails.cache.read(key)
+        {data: cached_value, is_from_cache: true}
       else
         yield_result = yield
         Rails.cache.write(key, yield_result, expires_in: expires_in)

--- a/app/services/forecast_service.rb
+++ b/app/services/forecast_service.rb
@@ -76,4 +76,12 @@ class ForecastService
     Rails.logger.error(message)
     raise ForecastError, message
   end
+
+  def convert_temp(temp_f)
+    if @country_code == 'CA'
+      ((temp_f - 32) * 5 / 9).round(2)
+    else
+      temp_f.round(2)
+    end
+  end
 end

--- a/app/services/forecast_service.rb
+++ b/app/services/forecast_service.rb
@@ -7,9 +7,10 @@ class ForecastService
   MAX_RETRIES = 3
 
   def initialize(country_code = 'US')
+    @api_key = ENV['OPENWEATHER_API_KEY']
     @options = {
       id: ENV.fetch('OPENWEATHER_API_ID', nil),
-      appid: ENV.fetch('OPENWEATHER_API_KEY'),
+      appid: @api_key,
       units: country_code == 'CA' ? 'metric' : 'imperial'
     }
   end

--- a/app/services/forecast_service.rb
+++ b/app/services/forecast_service.rb
@@ -5,11 +5,11 @@ class ForecastService
 
   BASE_URL = 'https://api.openweathermap.org/data/2.5'.freeze
 
-  def initialize
+  def initialize(country_code = 'US')
     @options = {
       id: ENV.fetch('OPENWEATHER_API_ID', nil),
       appid: ENV.fetch('OPENWEATHER_API_KEY'),
-      units: ENV.fetch('OPENWEATHER_UNITS', 'metric')
+      units: country_code == 'CA' ? 'metric' : 'imperial'
     }
   end
 

--- a/app/services/geocode_service.rb
+++ b/app/services/geocode_service.rb
@@ -14,13 +14,13 @@ class GeocodeService
 
   def coords_by_zipcode(zipcode, country_code = 'US', skip_cache: false)
     query = "#{zipcode},#{country_code}"
-    fetch_geo_info('zipcode', query, skip_cache: skip_cache)
+    fetch_geo_info('zipcode', zipcode, query, skip_cache: skip_cache)
   end
 
   private
 
-  def fetch_geo_info(prefix, query, skip_cache: false)
-    key = cache_key(prefix, query)
+  def fetch_geo_info(prefix, zipcpde, query, skip_cache: false)
+    key = cache_key(prefix, zipcpde)
     CachingService.fetch(key, expires_in: CACHE_EXPIRATION, skip_cache: skip_cache) do
       Rails.logger.info "Fetching geocode for #{query}"
       parsed_response = fetch_from_api(query)

--- a/app/services/geocode_service.rb
+++ b/app/services/geocode_service.rb
@@ -13,7 +13,7 @@ class GeocodeService
   MAX_RETRIES = 3
 
   def coords_by_address(address, skip_cache: false)
-    fetch_geo_info('address', address, skip_cache: skip_cache)
+    fetch_geo_info('address', address, address, skip_cache: skip_cache)
   end
 
   def coords_by_zipcode(zipcode, country_code = 'US', skip_cache: false)
@@ -28,9 +28,7 @@ class GeocodeService
 
   def fetch_geo_info(prefix, key, query, skip_cache: false)
     cache_key = cache_key(prefix, key)
-    Rails.logger.info "GeocodeService: Cache key: #{cache_key}"
     CachingService.fetch(cache_key, expires_in: CACHE_EXPIRATION, skip_cache: skip_cache) do
-      Rails.logger.info "GeocodeService: Cache miss, fetching from API for #{query}"
       with_retries(max_retries: MAX_RETRIES) { geocode(query) }
     end
   rescue StandardError => e

--- a/app/services/geocode_service.rb
+++ b/app/services/geocode_service.rb
@@ -18,15 +18,19 @@ class GeocodeService
 
   def coords_by_zipcode(zipcode, country_code = 'US', skip_cache: false)
     query = "#{zipcode},#{country_code}"
-    fetch_geo_info('zipcode', zipcode, query, skip_cache: skip_cache)
+    Rails.logger.info "GeocodeService: Fetching coords for #{query}"
+    result = fetch_geo_info('zipcode', zipcode, query, skip_cache: skip_cache)
+    Rails.logger.info "GeocodeService: Result for #{query}: #{result.inspect}"
+    result
   end
 
   private
 
   def fetch_geo_info(prefix, key, query, skip_cache: false)
     cache_key = cache_key(prefix, key)
+    Rails.logger.info "GeocodeService: Cache key: #{cache_key}"
     CachingService.fetch(cache_key, expires_in: CACHE_EXPIRATION, skip_cache: skip_cache) do
-      Rails.logger.info "Fetching geocode for #{query}"
+      Rails.logger.info "GeocodeService: Cache miss, fetching from API for #{query}"
       with_retries(max_retries: MAX_RETRIES) { geocode(query) }
     end
   rescue StandardError => e
@@ -34,8 +38,11 @@ class GeocodeService
   end
 
   def geocode(query)
+    Rails.logger.info "GeocodeService: Geocoding #{query}"
     parsed_response = fetch_from_api(query)
-    extract_location_info(parsed_response)
+    result = extract_location_info(parsed_response)
+    Rails.logger.info "GeocodeService: Geocoding result for #{query}: #{result.inspect}"
+    result
   end
 
   def fetch_from_api(address)

--- a/app/services/weather_service.rb
+++ b/app/services/weather_service.rb
@@ -8,19 +8,22 @@ class WeatherService
   CACHE_EXPIRATION = 30.minutes.freeze
   ZIP_PATTERN = /^\d{5}$/.freeze
 
-  def initialize(geocode_service: GeocodeService.new, forecast_service: ForecastService.new)
+  def initialize(geocode_service: GeocodeService.new, forecast_service: nil)
     @geocode_service = geocode_service
     @forecast_service = forecast_service
   end
 
   def fetch_weather(address_or_zip)
     location_info = fetch_location_info(address_or_zip)
+    country_code = location_info[:country_code]
+    @forecast_service ||= ForecastService.new(country_code)
     weather_data = fetch_weather_data(location_info)
 
     {
       is_from_cache: weather_data[:is_from_cache],
       forecast_data: weather_data[:data],
-      zip: location_info[:zip]
+      zip: location_info[:zip],
+      country_code: country_code
     }
   end
 

--- a/app/views/weathers/index.html.erb
+++ b/app/views/weathers/index.html.erb
@@ -25,9 +25,9 @@
       <thead>
         <tr>
           <th>Date</th>
-          <th>Temperature (°F)</th>
-          <th>High (°F)</th>
-          <th>Low (°F)</th>
+          <th>Temperature (<%= @temp_unit %>)</th>
+          <th>High (<%= @temp_unit %>)</th>
+          <th>Low (<%= @temp_unit %>)</th>
         </tr>
       </thead>
       <tbody>

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,7 @@ module WeatherCast
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.autoload_paths += %W(#{config.root}/app/models/concerns)
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
+    config.cache_store = :file_store, Rails.root.join("tmp", "cache")
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,8 +70,19 @@ RSpec.configure do |config|
 end
 
 require 'vcr'
+require 'webmock/rspec'
 
+# Add this configuration block
 VCR.configure do |config|
-  config.cassette_library_dir = 'spec/vcr_cassettes'
+  config.cassette_library_dir = "spec/vcr_cassettes"
   config.hook_into :webmock
+  config.configure_rspec_metadata!
+  config.allow_http_connections_when_no_cassette = false
+  config.default_cassette_options = {
+    record: :new_episodes,
+    match_requests_on: [:method, :host, :path]
+  }
+  # If you're using any API keys, you should filter them out here
+  config.filter_sensitive_data('<GOOGLE_API_KEY>') { ENV['GOOGLE_API_KEY'] }
+  config.filter_sensitive_data('<OPENWEATHER_API_KEY>') { ENV['OPENWEATHER_API_KEY'] }
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,8 @@ require_relative '../config/environment'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+require 'webmock/rspec'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -61,4 +63,15 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.before(:each) do
+    WebMock.disable_net_connect!(allow_localhost: true)
+  end
+end
+
+require 'vcr'
+
+VCR.configure do |config|
+  config.cassette_library_dir = 'spec/vcr_cassettes'
+  config.hook_into :webmock
 end

--- a/spec/requests/weathers_spec.rb
+++ b/spec/requests/weathers_spec.rb
@@ -2,23 +2,15 @@ require 'rails_helper'
 
 RSpec.describe "Weather Forecasts", type: :request do
   describe "GET /index" do
-    let(:weather_service) { instance_double("WeatherService") }
-
-    before do
-      allow(WeatherService).to receive(:new).and_return(weather_service)
-    end
-
     context "when a valid query is provided" do
-      before do
-        allow(weather_service).to receive(:fetch_weather).and_return(forecast_data: [{date: Time.zone.now, temp: '70', temp_max: '75', temp_min: '65'}], is_from_cache: false, zip: '12345')
-      end
-
       it "displays weather forecast" do
-        get weathers_path, params: { q: 'valid_query' }
-        expect(response).to have_http_status(:success)
-        expect(response.body).to include('Here is the 3-hour forecast')
+        VCR.use_cassette("valid_weather_query", record: :new_episodes) do
+          get weathers_path, params: { q: "90210" }  # Using Beverly Hills ZIP code as a known valid input
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include('Here is the 3-hour forecast')
+          expect(response.body).to include('90210')  # Check for the ZIP code in the response
+        end
       end
     end
-
   end
 end

--- a/spec/requests/weathers_spec.rb
+++ b/spec/requests/weathers_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Weather Forecasts", type: :request do
       end
 
       it "displays weather forecast" do
-        get weathers_index_path, params: { q: 'valid_query' }
+        get weathers_path, params: { q: 'valid_query' }
         expect(response).to have_http_status(:success)
         expect(response.body).to include('Here is the 3-hour forecast')
       end

--- a/spec/services/forecast_service_spec.rb
+++ b/spec/services/forecast_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ForecastService do
-  let(:service) { described_class.new }
+  let(:service) { ForecastService.new('US') }
   let(:lat) { 43.8986416 }
   let(:lon) { -79.4509662 }
   let(:cache_key) { "forecast_#{lat}_#{lon}" }

--- a/spec/services/geocode_service_spec.rb
+++ b/spec/services/geocode_service_spec.rb
@@ -2,89 +2,47 @@ require 'rails_helper'
 
 RSpec.describe GeocodeService do
   let(:service) { described_class.new }
-  let(:address) { '123 main st, New York, NY' }
-  let(:zipcode) { 12_345 }
-  let(:cache_key) { "geocode_#{address.gsub(/\s+/, '_').downcase}" }
-
-  fake_http_response = {
-    'results' => [
-      {
-        'geometry' => {
-          'location' => {
-            'lat' => 37.7749,
-            'lng' => -122.4194
-          }
-        },
-        'address_components' => [
-          {
-            'types' => ['locality'],
-            'short_name' => 'SF'
-          },
-          {
-            'types' => ['postal_code'],
-            'short_name' => '94103'
-          }
-        ]
-      }
-    ]
-  }
 
   describe '#coords_by_address' do
-    before do
-      allow(HTTParty).to receive(:get).and_return(double(body: fake_http_response.to_json, success?: true))
-    end
-
     context 'when fetching geolocation using address' do
-      it 'returns the correct result' do
-        result = service.coords_by_address(address)
-
-        expect(HTTParty).to have_received(:get).with(
-          'https://maps.googleapis.com/maps/api/geocode/json',
-          query: hash_including(address: address, key: ENV['GOOGLE_MAPS_API_KEY'])
-        )
-
-        expect(result).to eq({ data: { lat: 37.7749, lon: -122.4194, zip: '94103' }, is_from_cache: false })
+      before do
+        stub_request(:get, /maps\.googleapis\.com/)
+          .to_return(status: 200, body: {
+            results: [{
+              geometry: { location: { lat: 37.7749, lng: -122.4194 } },
+              address_components: [
+                { types: ['postal_code'], short_name: '94103' },
+                { types: ['country'], short_name: 'US' }
+              ]
+            }]
+          }.to_json, headers: { 'Content-Type' => 'application/json' })
       end
-    end
 
-    context 'when fetching geolocation using zipcode' do
       it 'returns the correct result' do
-        result = service.coords_by_address(zipcode)
-
-        expect(HTTParty).to have_received(:get).with(
-          'https://maps.googleapis.com/maps/api/geocode/json',
-          query: hash_including(address: zipcode, key: ENV['GOOGLE_MAPS_API_KEY'])
-        )
-
-        expect(result).to eq({ data: { lat: 37.7749, lon: -122.4194, zip: '94103' }, is_from_cache: false })
+        result = service.coords_by_address('San Francisco')
+        expect(result).to eq({ data: { lat: 37.7749, lon: -122.4194, zip: '94103', country_code: 'US' }, is_from_cache: false })
       end
     end
   end
 
-  describe 'caching' do
-    let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
-    let(:cache) { Rails.cache }
-
-    before do
-      allow(HTTParty).to receive(:get).and_return(double(body: fake_http_response.to_json, success?: true))
-      allow(Rails).to receive(:cache).and_return(memory_store)
-      Rails.cache.clear
-    end
-
-    context 'when skip_cache is false' do
-      it 'uses caching and returns the correct result' do
-        first_result = service.coords_by_address(address)
-        expect(first_result[:is_from_cache]).to eq(false)
-
-        second_result = service.coords_by_address(address)
-        expect(second_result[:is_from_cache]).to eq(true)
+  describe '#coords_by_zipcode' do
+    context 'when fetching geolocation using zipcode' do
+      before do
+        stub_request(:get, /maps\.googleapis\.com/)
+          .to_return(status: 200, body: {
+            results: [{
+              geometry: { location: { lat: 37.7749, lng: -122.4194 } },
+              address_components: [
+                { types: ['postal_code'], short_name: '94103' },
+                { types: ['country'], short_name: 'US' }
+              ]
+            }]
+          }.to_json, headers: { 'Content-Type' => 'application/json' })
       end
-    end
 
-    context 'when skip_cache is true' do
-      it 'bypasses caching and returns the correct result' do
-        result = service.coords_by_address(address, skip_cache: true)
-        expect(result[:is_from_cache]).to eq(false)
+      it 'returns the correct result' do
+        result = service.coords_by_zipcode('94103')
+        expect(result).to eq({ data: { lat: 37.7749, lon: -122.4194, zip: '94103', country_code: 'US' }, is_from_cache: false })
       end
     end
   end

--- a/spec/services/geocode_service_spec.rb
+++ b/spec/services/geocode_service_spec.rb
@@ -1,48 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe GeocodeService do
-  let(:service) { described_class.new }
-
   describe '#coords_by_address' do
     context 'when fetching geolocation using address' do
-      before do
-        stub_request(:get, /maps\.googleapis\.com/)
-          .to_return(status: 200, body: {
-            results: [{
-              geometry: { location: { lat: 37.7749, lng: -122.4194 } },
-              address_components: [
-                { types: ['postal_code'], short_name: '94103' },
-                { types: ['country'], short_name: 'US' }
-              ]
-            }]
-          }.to_json, headers: { 'Content-Type' => 'application/json' })
-      end
-
       it 'returns the correct result' do
-        result = service.coords_by_address('San Francisco')
-        expect(result).to eq({ data: { lat: 37.7749, lon: -122.4194, zip: '94103', country_code: 'US' }, is_from_cache: false })
-      end
-    end
-  end
+        VCR.use_cassette('geocode_service_address') do
+          service = GeocodeService.new
+          result = service.coords_by_address('1600 Amphitheatre Parkway, Mountain View, CA')
 
-  describe '#coords_by_zipcode' do
-    context 'when fetching geolocation using zipcode' do
-      before do
-        stub_request(:get, /maps\.googleapis\.com/)
-          .to_return(status: 200, body: {
-            results: [{
-              geometry: { location: { lat: 37.7749, lng: -122.4194 } },
-              address_components: [
-                { types: ['postal_code'], short_name: '94103' },
-                { types: ['country'], short_name: 'US' }
-              ]
-            }]
-          }.to_json, headers: { 'Content-Type' => 'application/json' })
-      end
-
-      it 'returns the correct result' do
-        result = service.coords_by_zipcode('94103')
-        expect(result).to eq({ data: { lat: 37.7749, lon: -122.4194, zip: '94103', country_code: 'US' }, is_from_cache: false })
+          expect(result[:data]).to include(
+            lat: be_within(0.01).of(37.4224764),
+            lon: be_within(0.01).of(-122.0842499),
+            zip: '94043',
+            country_code: 'US'
+          )
+        end
       end
     end
   end

--- a/spec/services/weather_service_spec.rb
+++ b/spec/services/weather_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe WeatherService do
 
   before do
     allow(geocode_service).to receive(:coords_by_zipcode).and_return({data: { lat: 40.7128, lon: -74.0060, zip: '10007'}, is_from_cache: false })
-    allow(geocode_service).to receive(:coords_by_address).and_return({data: { lat: 40.7128, lon: -74.0060, zip: '10007'}, is_from_cache: false })
+    allow(geocode_service).to receive(:coords_by_address).and_return({data: { lat: 40.7128, lon: -74.0060, zip: '12345', country_code: 'US' }, is_from_cache: false })
     allow(forecast_service).to receive(:with_lat_lon).and_return(fake_forecast_data)
   end
 

--- a/spec/vcr_cassettes/geocode_service_address.yml
+++ b/spec/vcr_cassettes/geocode_service_address.yml
@@ -1,0 +1,96 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/geocode/json?address=1600%20Amphitheatre%20Parkway,%20Mountain%20View,%20CA&key=AIzaSyDG-FrpSf88xFZVrs-c0zhEHosvDEvqUXc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 09 Oct 2024 02:53:29 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Vary:
+      - Accept-Language
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Goog-Maps-Metro-Area:
+      - San Jose, CA
+      Content-Security-Policy-Report-Only:
+      - script-src 'none'; form-action 'none'; frame-src 'none'; report-uri https://csp.withgoogle.com/csp/scaffolding/msaifdggmnwc:229:0
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to=coop_reporting
+      Report-To:
+      - '{"group":"coop_reporting","max_age":2592000,"endpoints":[{"url":"https://csp.withgoogle.com/csp/report-to/scaffolding/msaifdggmnwc:229:0"}],}'
+      Server:
+      - mafe
+      Content-Length:
+      - '2849'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=56
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+    body:
+      encoding: UTF-8
+      string: "{\n   \"results\" : \n   [\n      {\n         \"address_components\"
+        : \n         [\n            {\n               \"long_name\" : \"1600\",\n
+        \              \"short_name\" : \"1600\",\n               \"types\" : \n               [\n
+        \                 \"street_number\"\n               ]\n            },\n            {\n
+        \              \"long_name\" : \"Amphitheatre Parkway\",\n               \"short_name\"
+        : \"Amphitheatre Pkwy\",\n               \"types\" : \n               [\n
+        \                 \"route\"\n               ]\n            },\n            {\n
+        \              \"long_name\" : \"Mountain View\",\n               \"short_name\"
+        : \"Mountain View\",\n               \"types\" : \n               [\n                  \"locality\",\n
+        \                 \"political\"\n               ]\n            },\n            {\n
+        \              \"long_name\" : \"Santa Clara County\",\n               \"short_name\"
+        : \"Santa Clara County\",\n               \"types\" : \n               [\n
+        \                 \"administrative_area_level_2\",\n                  \"political\"\n
+        \              ]\n            },\n            {\n               \"long_name\"
+        : \"California\",\n               \"short_name\" : \"CA\",\n               \"types\"
+        : \n               [\n                  \"administrative_area_level_1\",\n
+        \                 \"political\"\n               ]\n            },\n            {\n
+        \              \"long_name\" : \"United States\",\n               \"short_name\"
+        : \"US\",\n               \"types\" : \n               [\n                  \"country\",\n
+        \                 \"political\"\n               ]\n            },\n            {\n
+        \              \"long_name\" : \"94043\",\n               \"short_name\" :
+        \"94043\",\n               \"types\" : \n               [\n                  \"postal_code\"\n
+        \              ]\n            },\n            {\n               \"long_name\"
+        : \"1351\",\n               \"short_name\" : \"1351\",\n               \"types\"
+        : \n               [\n                  \"postal_code_suffix\"\n               ]\n
+        \           }\n         ],\n         \"formatted_address\" : \"1600 Amphitheatre
+        Pkwy, Mountain View, CA 94043, USA\",\n         \"geometry\" : \n         {\n
+        \           \"location\" : \n            {\n               \"lat\" : 37.4214795,\n
+        \              \"lng\" : -122.0843013\n            },\n            \"location_type\"
+        : \"ROOFTOP\",\n            \"viewport\" : \n            {\n               \"northeast\"
+        : \n               {\n                  \"lat\" : 37.4214795,\n                  \"lng\"
+        : -122.0834892697085\n               },\n               \"southwest\" : \n
+        \              {\n                  \"lat\" : 37.4170393,\n                  \"lng\"
+        : -122.0861872302915\n               }\n            }\n         },\n         \"place_id\"
+        : \"ChIJF4Yf2Ry7j4AR__1AkytDyAE\",\n         \"plus_code\" : \n         {\n
+        \           \"compound_code\" : \"CWC8+J5 Mountain View, CA\",\n            \"global_code\"
+        : \"849VCWC8+J5\"\n         },\n         \"types\" : \n         [\n            \"street_address\"\n
+        \        ]\n      }\n   ],\n   \"status\" : \"OK\"\n}"
+  recorded_at: Wed, 09 Oct 2024 02:53:29 GMT
+recorded_with: VCR 6.3.1

--- a/spec/vcr_cassettes/valid_weather_query.yml
+++ b/spec/vcr_cassettes/valid_weather_query.yml
@@ -1,0 +1,211 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/geocode/json?address=90210,US&key=AIzaSyDG-FrpSf88xFZVrs-c0zhEHosvDEvqUXc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 09 Oct 2024 02:55:34 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Vary:
+      - Accept-Language
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Goog-Maps-Metro-Area:
+      - Los Angeles, CA
+      Content-Security-Policy-Report-Only:
+      - script-src 'none'; form-action 'none'; frame-src 'none'; report-uri https://csp.withgoogle.com/csp/scaffolding/msaifdggmnwc:229:0
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to=coop_reporting
+      Report-To:
+      - '{"group":"coop_reporting","max_age":2592000,"endpoints":[{"url":"https://csp.withgoogle.com/csp/report-to/scaffolding/msaifdggmnwc:229:0"}],}'
+      Server:
+      - mafe
+      Content-Length:
+      - '2492'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=120
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+    body:
+      encoding: UTF-8
+      string: "{\n   \"results\" : \n   [\n      {\n         \"address_components\"
+        : \n         [\n            {\n               \"long_name\" : \"90210\",\n
+        \              \"short_name\" : \"90210\",\n               \"types\" : \n
+        \              [\n                  \"postal_code\"\n               ]\n            },\n
+        \           {\n               \"long_name\" : \"Beverly Hills\",\n               \"short_name\"
+        : \"Beverly Hills\",\n               \"types\" : \n               [\n                  \"locality\",\n
+        \                 \"political\"\n               ]\n            },\n            {\n
+        \              \"long_name\" : \"Los Angeles County\",\n               \"short_name\"
+        : \"Los Angeles County\",\n               \"types\" : \n               [\n
+        \                 \"administrative_area_level_2\",\n                  \"political\"\n
+        \              ]\n            },\n            {\n               \"long_name\"
+        : \"California\",\n               \"short_name\" : \"CA\",\n               \"types\"
+        : \n               [\n                  \"administrative_area_level_1\",\n
+        \                 \"political\"\n               ]\n            },\n            {\n
+        \              \"long_name\" : \"United States\",\n               \"short_name\"
+        : \"US\",\n               \"types\" : \n               [\n                  \"country\",\n
+        \                 \"political\"\n               ]\n            }\n         ],\n
+        \        \"formatted_address\" : \"Beverly Hills, CA 90210, USA\",\n         \"geometry\"
+        : \n         {\n            \"bounds\" : \n            {\n               \"northeast\"
+        : \n               {\n                  \"lat\" : 34.1354771,\n                  \"lng\"
+        : -118.3867129\n               },\n               \"southwest\" : \n               {\n
+        \                 \"lat\" : 34.065094,\n                  \"lng\" : -118.4423781\n
+        \              }\n            },\n            \"location\" : \n            {\n
+        \              \"lat\" : 34.1030032,\n               \"lng\" : -118.4104684\n
+        \           },\n            \"location_type\" : \"APPROXIMATE\",\n            \"viewport\"
+        : \n            {\n               \"northeast\" : \n               {\n                  \"lat\"
+        : 34.1354771,\n                  \"lng\" : -118.3867129\n               },\n
+        \              \"southwest\" : \n               {\n                  \"lat\"
+        : 34.065094,\n                  \"lng\" : -118.4423781\n               }\n
+        \           }\n         },\n         \"place_id\" : \"ChIJ7xfS-zW8woARXNkAJzX5Hs8\",\n
+        \        \"postcode_localities\" : \n         [\n            \"Beverly Hills\",\n
+        \           \"Los Angeles\"\n         ],\n         \"types\" : \n         [\n
+        \           \"postal_code\"\n         ]\n      }\n   ],\n   \"status\" : \"OK\"\n}"
+  recorded_at: Wed, 09 Oct 2024 02:55:34 GMT
+- request:
+    method: get
+    uri: https://api.openweathermap.org/data/2.5/forecast?appid=<OPENWEATHER_API_KEY>&id=<OPENWEATHER_API_KEY>&lat=34.1030032&lon=-118.4104684&units=imperial
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty
+      Date:
+      - Wed, 09 Oct 2024 02:55:34 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '15727'
+      Connection:
+      - keep-alive
+      X-Cache-Key:
+      - "/data/2.5/forecast?id=<OPENWEATHER_API_KEY>&lat=34.1&lon=-118.41&units=imperial"
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, POST
+    body:
+      encoding: UTF-8
+      string: '{"cod":"200","message":0,"cnt":40,"list":[{"dt":1728442800,"main":{"temp":74.95,"feels_like":74.3,"temp_min":73.08,"temp_max":74.95,"pressure":1010,"sea_level":1010,"grnd_level":986,"humidity":46,"temp_kf":1.04},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01n"}],"clouds":{"all":0},"wind":{"speed":3.2,"deg":190,"gust":2.64},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-09
+        03:00:00"},{"dt":1728453600,"main":{"temp":73.62,"feels_like":72.93,"temp_min":70.93,"temp_max":73.62,"pressure":1011,"sea_level":1011,"grnd_level":987,"humidity":48,"temp_kf":1.49},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01n"}],"clouds":{"all":0},"wind":{"speed":2.8,"deg":181,"gust":3.36},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-09
+        06:00:00"},{"dt":1728464400,"main":{"temp":71.91,"feels_like":71.15,"temp_min":70.39,"temp_max":71.91,"pressure":1011,"sea_level":1011,"grnd_level":987,"humidity":50,"temp_kf":0.84},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01n"}],"clouds":{"all":0},"wind":{"speed":0.94,"deg":98,"gust":1.81},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-09
+        09:00:00"},{"dt":1728475200,"main":{"temp":70.75,"feels_like":69.75,"temp_min":70.75,"temp_max":70.75,"pressure":1012,"sea_level":1012,"grnd_level":987,"humidity":47,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01n"}],"clouds":{"all":0},"wind":{"speed":0.76,"deg":262,"gust":1.86},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-09
+        12:00:00"},{"dt":1728486000,"main":{"temp":71.11,"feels_like":70,"temp_min":71.11,"temp_max":71.11,"pressure":1013,"sea_level":1013,"grnd_level":988,"humidity":44,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01d"}],"clouds":{"all":0},"wind":{"speed":0.72,"deg":235,"gust":1.43},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-09
+        15:00:00"},{"dt":1728496800,"main":{"temp":79.03,"feels_like":79.03,"temp_min":79.03,"temp_max":79.03,"pressure":1013,"sea_level":1013,"grnd_level":989,"humidity":31,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01d"}],"clouds":{"all":0},"wind":{"speed":4.21,"deg":202,"gust":2.26},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-09
+        18:00:00"},{"dt":1728507600,"main":{"temp":81.86,"feels_like":80.24,"temp_min":81.86,"temp_max":81.86,"pressure":1012,"sea_level":1012,"grnd_level":987,"humidity":28,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01d"}],"clouds":{"all":2},"wind":{"speed":5.48,"deg":198,"gust":5.26},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-09
+        21:00:00"},{"dt":1728518400,"main":{"temp":79.93,"feels_like":79.93,"temp_min":79.93,"temp_max":79.93,"pressure":1011,"sea_level":1011,"grnd_level":986,"humidity":32,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01d"}],"clouds":{"all":2},"wind":{"speed":6.06,"deg":182,"gust":5.41},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-10
+        00:00:00"},{"dt":1728529200,"main":{"temp":76.42,"feels_like":75.6,"temp_min":76.42,"temp_max":76.42,"pressure":1013,"sea_level":1013,"grnd_level":988,"humidity":39,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01n"}],"clouds":{"all":0},"wind":{"speed":1.72,"deg":154,"gust":2.37},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-10
+        03:00:00"},{"dt":1728540000,"main":{"temp":74.3,"feels_like":73.36,"temp_min":74.3,"temp_max":74.3,"pressure":1014,"sea_level":1014,"grnd_level":989,"humidity":41,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01n"}],"clouds":{"all":0},"wind":{"speed":2.44,"deg":147,"gust":2.89},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-10
+        06:00:00"},{"dt":1728550800,"main":{"temp":71.69,"feels_like":70.68,"temp_min":71.69,"temp_max":71.69,"pressure":1014,"sea_level":1014,"grnd_level":989,"humidity":45,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01n"}],"clouds":{"all":0},"wind":{"speed":2.46,"deg":133,"gust":2.89},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-10
+        09:00:00"},{"dt":1728561600,"main":{"temp":71.19,"feels_like":70.03,"temp_min":71.19,"temp_max":71.19,"pressure":1013,"sea_level":1013,"grnd_level":989,"humidity":43,"temp_kf":0},"weather":[{"id":801,"main":"Clouds","description":"few
+        clouds","icon":"02n"}],"clouds":{"all":15},"wind":{"speed":1.19,"deg":89,"gust":1.59},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-10
+        12:00:00"},{"dt":1728572400,"main":{"temp":71.91,"feels_like":70.63,"temp_min":71.91,"temp_max":71.91,"pressure":1014,"sea_level":1014,"grnd_level":989,"humidity":39,"temp_kf":0},"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03d"}],"clouds":{"all":36},"wind":{"speed":0.58,"deg":323,"gust":0.92},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-10
+        15:00:00"},{"dt":1728583200,"main":{"temp":78.55,"feels_like":77.56,"temp_min":78.55,"temp_max":78.55,"pressure":1015,"sea_level":1015,"grnd_level":990,"humidity":31,"temp_kf":0},"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03d"}],"clouds":{"all":50},"wind":{"speed":4.41,"deg":181,"gust":3.13},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-10
+        18:00:00"},{"dt":1728594000,"main":{"temp":81.41,"feels_like":79.86,"temp_min":81.41,"temp_max":81.41,"pressure":1013,"sea_level":1013,"grnd_level":989,"humidity":27,"temp_kf":0},"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04d"}],"clouds":{"all":83},"wind":{"speed":5.35,"deg":186,"gust":5.35},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-10
+        21:00:00"},{"dt":1728604800,"main":{"temp":78.69,"feels_like":77.67,"temp_min":78.69,"temp_max":78.69,"pressure":1013,"sea_level":1013,"grnd_level":988,"humidity":30,"temp_kf":0},"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04d"}],"clouds":{"all":62},"wind":{"speed":5.32,"deg":186,"gust":5.61},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-11
+        00:00:00"},{"dt":1728615600,"main":{"temp":76.53,"feels_like":75.4,"temp_min":76.53,"temp_max":76.53,"pressure":1013,"sea_level":1013,"grnd_level":989,"humidity":32,"temp_kf":0},"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"clouds":{"all":100},"wind":{"speed":1.57,"deg":204,"gust":1.72},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-11
+        03:00:00"},{"dt":1728626400,"main":{"temp":74.12,"feels_like":72.93,"temp_min":74.12,"temp_max":74.12,"pressure":1014,"sea_level":1014,"grnd_level":990,"humidity":36,"temp_kf":0},"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"clouds":{"all":99},"wind":{"speed":2.3,"deg":135,"gust":2.71},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-11
+        06:00:00"},{"dt":1728637200,"main":{"temp":72.68,"feels_like":71.35,"temp_min":72.68,"temp_max":72.68,"pressure":1014,"sea_level":1014,"grnd_level":990,"humidity":36,"temp_kf":0},"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"clouds":{"all":100},"wind":{"speed":1.92,"deg":114,"gust":1.61},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-11
+        09:00:00"},{"dt":1728648000,"main":{"temp":71.92,"feels_like":70.47,"temp_min":71.92,"temp_max":71.92,"pressure":1014,"sea_level":1014,"grnd_level":990,"humidity":35,"temp_kf":0},"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"clouds":{"all":100},"wind":{"speed":1.23,"deg":88,"gust":1.01},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-11
+        12:00:00"},{"dt":1728658800,"main":{"temp":71.96,"feels_like":70.36,"temp_min":71.96,"temp_max":71.96,"pressure":1015,"sea_level":1015,"grnd_level":991,"humidity":32,"temp_kf":0},"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"clouds":{"all":97},"wind":{"speed":0.6,"deg":48,"gust":0.92},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-11
+        15:00:00"},{"dt":1728669600,"main":{"temp":78.76,"feels_like":78.76,"temp_min":78.76,"temp_max":78.76,"pressure":1016,"sea_level":1016,"grnd_level":991,"humidity":24,"temp_kf":0},"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04d"}],"clouds":{"all":100},"wind":{"speed":4.32,"deg":165,"gust":3.83},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-11
+        18:00:00"},{"dt":1728680400,"main":{"temp":81.23,"feels_like":79.57,"temp_min":81.23,"temp_max":81.23,"pressure":1015,"sea_level":1015,"grnd_level":990,"humidity":24,"temp_kf":0},"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03d"}],"clouds":{"all":33},"wind":{"speed":5.26,"deg":200,"gust":3.83},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-11
+        21:00:00"},{"dt":1728691200,"main":{"temp":79.45,"feels_like":79.45,"temp_min":79.45,"temp_max":79.45,"pressure":1014,"sea_level":1014,"grnd_level":989,"humidity":27,"temp_kf":0},"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03d"}],"clouds":{"all":37},"wind":{"speed":5.79,"deg":198,"gust":5.57},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-12
+        00:00:00"},{"dt":1728702000,"main":{"temp":76.1,"feels_like":75.06,"temp_min":76.1,"temp_max":76.1,"pressure":1015,"sea_level":1015,"grnd_level":990,"humidity":35,"temp_kf":0},"weather":[{"id":803,"main":"Clouds","description":"broken
+        clouds","icon":"04n"}],"clouds":{"all":82},"wind":{"speed":2.06,"deg":204,"gust":2.39},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-12
+        03:00:00"},{"dt":1728712800,"main":{"temp":73.74,"feels_like":72.64,"temp_min":73.74,"temp_max":73.74,"pressure":1016,"sea_level":1016,"grnd_level":991,"humidity":39,"temp_kf":0},"weather":[{"id":804,"main":"Clouds","description":"overcast
+        clouds","icon":"04n"}],"clouds":{"all":87},"wind":{"speed":3,"deg":129,"gust":3.33},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-12
+        06:00:00"},{"dt":1728723600,"main":{"temp":71.04,"feels_like":69.91,"temp_min":71.04,"temp_max":71.04,"pressure":1016,"sea_level":1016,"grnd_level":991,"humidity":44,"temp_kf":0},"weather":[{"id":802,"main":"Clouds","description":"scattered
+        clouds","icon":"03n"}],"clouds":{"all":33},"wind":{"speed":2.21,"deg":165,"gust":3.06},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-12
+        09:00:00"},{"dt":1728734400,"main":{"temp":69.98,"feels_like":68.7,"temp_min":69.98,"temp_max":69.98,"pressure":1015,"sea_level":1015,"grnd_level":991,"humidity":43,"temp_kf":0},"weather":[{"id":801,"main":"Clouds","description":"few
+        clouds","icon":"02n"}],"clouds":{"all":20},"wind":{"speed":0.94,"deg":149,"gust":1.5},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-12
+        12:00:00"},{"dt":1728745200,"main":{"temp":69.85,"feels_like":68.56,"temp_min":69.85,"temp_max":69.85,"pressure":1016,"sea_level":1016,"grnd_level":991,"humidity":43,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01d"}],"clouds":{"all":2},"wind":{"speed":0.92,"deg":152,"gust":1.03},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-12
+        15:00:00"},{"dt":1728756000,"main":{"temp":75.94,"feels_like":74.79,"temp_min":75.94,"temp_max":75.94,"pressure":1017,"sea_level":1017,"grnd_level":992,"humidity":33,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01d"}],"clouds":{"all":1},"wind":{"speed":4.59,"deg":171,"gust":3.62},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-12
+        18:00:00"},{"dt":1728766800,"main":{"temp":78.3,"feels_like":77.23,"temp_min":78.3,"temp_max":78.3,"pressure":1015,"sea_level":1015,"grnd_level":990,"humidity":30,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01d"}],"clouds":{"all":1},"wind":{"speed":5.91,"deg":196,"gust":4.43},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-12
+        21:00:00"},{"dt":1728777600,"main":{"temp":76.12,"feels_like":74.98,"temp_min":76.12,"temp_max":76.12,"pressure":1013,"sea_level":1013,"grnd_level":989,"humidity":33,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01d"}],"clouds":{"all":2},"wind":{"speed":5.61,"deg":203,"gust":4.94},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-13
+        00:00:00"},{"dt":1728788400,"main":{"temp":73.09,"feels_like":71.98,"temp_min":73.09,"temp_max":73.09,"pressure":1014,"sea_level":1014,"grnd_level":989,"humidity":40,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01n"}],"clouds":{"all":0},"wind":{"speed":2.66,"deg":201,"gust":2.3},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-13
+        03:00:00"},{"dt":1728799200,"main":{"temp":70.32,"feels_like":69.35,"temp_min":70.32,"temp_max":70.32,"pressure":1014,"sea_level":1014,"grnd_level":990,"humidity":49,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01n"}],"clouds":{"all":0},"wind":{"speed":4.09,"deg":158,"gust":4.21},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-13
+        06:00:00"},{"dt":1728810000,"main":{"temp":67.82,"feels_like":66.94,"temp_min":67.82,"temp_max":67.82,"pressure":1014,"sea_level":1014,"grnd_level":989,"humidity":56,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01n"}],"clouds":{"all":0},"wind":{"speed":3.6,"deg":163,"gust":3.29},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-13
+        09:00:00"},{"dt":1728820800,"main":{"temp":66.69,"feels_like":65.79,"temp_min":66.69,"temp_max":66.69,"pressure":1014,"sea_level":1014,"grnd_level":989,"humidity":58,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01n"}],"clouds":{"all":0},"wind":{"speed":1.83,"deg":208,"gust":0.56},"visibility":10000,"pop":0,"sys":{"pod":"n"},"dt_txt":"2024-10-13
+        12:00:00"},{"dt":1728831600,"main":{"temp":66.16,"feels_like":65.16,"temp_min":66.16,"temp_max":66.16,"pressure":1015,"sea_level":1015,"grnd_level":990,"humidity":57,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01d"}],"clouds":{"all":0},"wind":{"speed":3.13,"deg":221,"gust":1.14},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-13
+        15:00:00"},{"dt":1728842400,"main":{"temp":71.24,"feels_like":70.23,"temp_min":71.24,"temp_max":71.24,"pressure":1016,"sea_level":1016,"grnd_level":991,"humidity":46,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01d"}],"clouds":{"all":0},"wind":{"speed":5.41,"deg":194,"gust":2.73},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-13
+        18:00:00"},{"dt":1728853200,"main":{"temp":74.97,"feels_like":74.14,"temp_min":74.97,"temp_max":74.97,"pressure":1014,"sea_level":1014,"grnd_level":989,"humidity":42,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01d"}],"clouds":{"all":0},"wind":{"speed":7.27,"deg":195,"gust":4.83},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-13
+        21:00:00"},{"dt":1728864000,"main":{"temp":71.42,"feels_like":70.7,"temp_min":71.42,"temp_max":71.42,"pressure":1013,"sea_level":1013,"grnd_level":989,"humidity":52,"temp_kf":0},"weather":[{"id":800,"main":"Clear","description":"clear
+        sky","icon":"01d"}],"clouds":{"all":1},"wind":{"speed":6.73,"deg":210,"gust":6.22},"visibility":10000,"pop":0,"sys":{"pod":"d"},"dt_txt":"2024-10-14
+        00:00:00"}],"city":{"id":5328041,"name":"Beverly Hills","coord":{"lat":34.103,"lon":-118.4105},"country":"US","population":34109,"timezone":-25200,"sunrise":1728395616,"sunset":1728437286}}'
+  recorded_at: Wed, 09 Oct 2024 02:55:34 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
## Summary by Sourcery

Refactor the weather fetching process to use GeocodeService and ForecastService directly, introducing temperature unit selection based on country code. Implement retry logic for API requests and enhance logging. Update tests to use VCR for consistent HTTP interaction testing.

New Features:
- Introduce temperature unit selection based on country code, displaying temperatures in Celsius for Canada and Fahrenheit for other countries.

Enhancements:
- Refactor weather fetching logic to directly use GeocodeService and ForecastService, removing the intermediate WeatherService.
- Add retry logic with exponential backoff for API requests in GeocodeService and ForecastService to improve reliability.
- Enhance logging in GeocodeService to provide more detailed information about geocoding requests and results.

Build:
- Add VCR gem to the Gemfile for recording HTTP interactions in tests.

Tests:
- Update weather forecast request tests to use VCR for recording and replaying HTTP interactions, ensuring consistent test results.